### PR TITLE
Fix for compiling on Windows

### DIFF
--- a/cfcomponent/logging.go
+++ b/cfcomponent/logging.go
@@ -3,10 +3,8 @@ package cfcomponent
 import (
 	"github.com/cloudfoundry/gosteno"
 	"os"
-	"os/signal"
 	"runtime/pprof"
 	"strings"
-	"syscall"
 )
 
 var Logger *gosteno.Logger
@@ -31,7 +29,7 @@ func NewLogger(verbose bool, logFilePath, name string, config Config) *gosteno.L
 	}
 
 	if config.Syslog != "" {
-		loggingConfig.Sinks = append(loggingConfig.Sinks, gosteno.NewSyslogSink(config.Syslog))
+		loggingConfig.Sinks = append(loggingConfig.Sinks, GetNewSyslogSink(config.Syslog))
 	}
 
 	gosteno.Init(loggingConfig)
@@ -48,11 +46,4 @@ func setGlobalLogger(logger *gosteno.Logger) {
 func DumpGoRoutine() {
 	goRoutineProfiles := pprof.Lookup("goroutine")
 	goRoutineProfiles.WriteTo(os.Stdout, 2)
-}
-
-func RegisterGoRoutineDumpSignalChannel() chan os.Signal {
-	threadDumpChan := make(chan os.Signal)
-	signal.Notify(threadDumpChan, syscall.SIGUSR1)
-
-	return threadDumpChan
 }

--- a/cfcomponent/logging_unix.go
+++ b/cfcomponent/logging_unix.go
@@ -1,0 +1,21 @@
+// +build !windows,!plan9
+
+package cfcomponent
+
+import (
+	"github.com/cloudfoundry/gosteno"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func GetNewSyslogSink(namespace string) *gosteno.Syslog {
+	return gosteno.NewSyslogSink(namespace)
+}
+
+func RegisterGoRoutineDumpSignalChannel() chan os.Signal {
+	threadDumpChan := make(chan os.Signal)
+	signal.Notify(threadDumpChan, syscall.SIGUSR1)
+
+	return threadDumpChan
+}

--- a/cfcomponent/logging_windows.go
+++ b/cfcomponent/logging_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package cfcomponent
+
+import (
+	"github.com/cloudfoundry/gosteno"
+	"os"
+)
+
+func GetNewSyslogSink(namespace string) gosteno.Sink {
+	panic("Syslog is not supported on windows")
+	return nil
+}
+
+func RegisterGoRoutineDumpSignalChannel() chan os.Signal {
+	threadDumpChan := make(chan os.Signal)
+
+	return threadDumpChan
+}


### PR DESCRIPTION
Split logging.go code into platform specific files.
Some of the functionality is not available on windows.
