### PR TITLE
Support new yagnats

### DIFF
--- a/cfcomponent/config.go
+++ b/cfcomponent/config.go
@@ -17,24 +17,17 @@ type Config struct {
 	NatsPort   int
 	NatsUser   string
 	NatsPass   string
-	MbusClient yagnats.NATSClient
+	MbusClient yagnats.ApceraWrapperNATSClient
 }
 
-var DefaultYagnatsClientProvider = func(logger *gosteno.Logger, c *Config) (natsClient yagnats.NATSClient, err error) {
-	members := []yagnats.ConnectionProvider{}
+var DefaultYagnatsClientProvider = func(logger *gosteno.Logger, c *Config) (natsClient yagnats.ApceraWrapperNATSClient, err error) {
+	members := make([]string, 0)
 	for _, natsHost := range c.NatsHosts {
-		members = append(members, &yagnats.ConnectionInfo{
-			Addr:     fmt.Sprintf("%s:%d", natsHost, c.NatsPort),
-			Username: c.NatsUser,
-			Password: c.NatsPass,
-		})
+		members = append(members, fmt.Sprintf("nats://%s:%s@%s:%d", c.NatsUser, c.NatsPass, natsHost, c.NatsPort))
 	}
 
-	connectionInfo := &yagnats.ConnectionCluster{
-		Members: members,
-	}
-	natsClient = yagnats.NewClient()
-	err = natsClient.Connect(connectionInfo)
+	natsClient = yagnats.NewApceraClientWrapper(members)
+	err = natsClient.Connect()
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Could not connect to NATS: %v", err.Error()))
 	}

--- a/clientpool/loggregator_client_pool.go
+++ b/clientpool/loggregator_client_pool.go
@@ -14,17 +14,17 @@ import (
 var ErrorEmptyClientPool = errors.New("loggregator client pool is empty")
 
 type LoggregatorClientPool struct {
-	clients              map[string]loggregatorclient.LoggregatorClient
-	logger               *gosteno.Logger
-	loggregatorPort      int
+	clients         map[string]loggregatorclient.LoggregatorClient
+	logger          *gosteno.Logger
+	loggregatorPort int
 	sync.RWMutex
 }
 
 func NewLoggregatorClientPool(logger *gosteno.Logger, port int) *LoggregatorClientPool {
 	return &LoggregatorClientPool{
-		loggregatorPort:      port,
-		clients:              make(map[string]loggregatorclient.LoggregatorClient),
-		logger:               logger,
+		loggregatorPort: port,
+		clients:         make(map[string]loggregatorclient.LoggregatorClient),
+		logger:          logger,
 	}
 }
 


### PR DESCRIPTION
Yagnats master deprecated numerous APIs as a result of #78730030. The
new code uses apcera's nats client directly. We'd like to update
loggregatorlib to also use this code path to talk to nats.

[#78730030]
