### PR TITLE
Add job_name property to announce messages

### DIFF
--- a/cfcomponent/component.go
+++ b/cfcomponent/component.go
@@ -24,6 +24,7 @@ type Component struct {
 	StatusPort        uint16
 	StatusCredentials []string
 	Instrumentables   []instrumentation.Instrumentable
+	JobName           string
 }
 
 const (
@@ -31,7 +32,7 @@ const (
 	password
 )
 
-func NewComponent(logger *gosteno.Logger, componentType string, index uint, heathMonitor HealthMonitor, statusPort uint16, statusCreds []string, instrumentables []instrumentation.Instrumentable) (Component, error) {
+func NewComponent(logger *gosteno.Logger, componentType string, index uint, heathMonitor HealthMonitor, statusPort uint16, statusCreds []string, instrumentables []instrumentation.Instrumentable, optionalJobName ...string) (Component, error) {
 	ip, err := localip.LocalIP()
 	if err != nil {
 		return Component{}, err
@@ -61,6 +62,11 @@ func NewComponent(logger *gosteno.Logger, componentType string, index uint, heat
 		statusCreds = []string{user, pass}
 	}
 
+	var jobName string
+	if len(optionalJobName) > 0 {
+		jobName = optionalJobName[0]
+	}
+
 	return Component{
 		Logger:            logger,
 		IpAddress:         ip,
@@ -71,6 +77,7 @@ func NewComponent(logger *gosteno.Logger, componentType string, index uint, heat
 		StatusPort:        statusPort,
 		StatusCredentials: statusCreds,
 		Instrumentables:   instrumentables,
+		JobName:           jobName,
 	}, nil
 }
 

--- a/cfcomponent/registrars/collectorregistrar/collector_messages.go
+++ b/cfcomponent/registrars/collectorregistrar/collector_messages.go
@@ -12,6 +12,7 @@ const DiscoverComponentMessageSubject = "vcap.component.discover"
 type AnnounceComponentMessage struct {
 	Type        string   `json:"type"`
 	Index       uint     `json:"index"`
+	JobName     string   `json:"job_name,omitempty"`
 	Host        string   `json:"host"`
 	UUID        string   `json:"uuid"`
 	Credentials []string `json:"credentials"`
@@ -21,6 +22,7 @@ func NewAnnounceComponentMessage(cfc cfcomponent.Component) (message *AnnounceCo
 	message = &AnnounceComponentMessage{
 		Type:        cfc.Type,
 		Index:       cfc.Index,
+		JobName:     cfc.JobName,
 		Host:        fmt.Sprintf("%s:%d", cfc.IpAddress, cfc.StatusPort),
 		UUID:        fmt.Sprintf("%d-%s", cfc.Index, cfc.UUID),
 		Credentials: cfc.StatusCredentials,

--- a/cfcomponent/registrars/collectorregistrar/collectormessage_test.go
+++ b/cfcomponent/registrars/collectorregistrar/collectormessage_test.go
@@ -1,0 +1,42 @@
+package collectorregistrar_test
+
+import (
+	"encoding/json"
+
+	"github.com/cloudfoundry/loggregatorlib/cfcomponent"
+	"github.com/cloudfoundry/loggregatorlib/cfcomponent/registrars/collectorregistrar"
+	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Collectormessages", func() {
+	Context("given a component without a jobName", func() {
+		var component cfcomponent.Component
+
+		BeforeEach(func() {
+			component, _ = cfcomponent.NewComponent(loggertesthelper.Logger(), "compType", 3, nil, 9999, []string{"username", "password"}, nil)
+			component.UUID = "OurUUID"
+		})
+
+		It("should not marshal jobName to JSON", func() {
+			json, _ := json.Marshal(collectorregistrar.NewAnnounceComponentMessage(component))
+			Expect(json).To(MatchRegexp(`^\{"type":"compType","index":3,"host":"[^:]*:9999","uuid":"3-OurUUID","credentials":\["username","password"\]\}$`))
+		})
+	})
+
+	Context("given a component with a jobName", func() {
+		var component cfcomponent.Component
+
+		BeforeEach(func() {
+			component, _ = cfcomponent.NewComponent(loggertesthelper.Logger(), "compType", 3, nil, 9999, []string{"username", "password"}, nil, "jobname")
+			component.UUID = "OurUUID"
+		})
+
+		It("should marshal jobName to JSON", func() {
+			json, _ := json.Marshal(collectorregistrar.NewAnnounceComponentMessage(component))
+			Expect(json).To(MatchRegexp(`^\{"type":"compType","index":3,"job_name":"jobname","host":"[^:]*:9999","uuid":"3-OurUUID","credentials":\["username","password"\]\}$`))
+		})
+
+	})
+})

--- a/cfcomponent/registrars/collectorregistrar/collectorregistrar_test.go
+++ b/cfcomponent/registrars/collectorregistrar/collectorregistrar_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Collectorregistrar", func() {
 
 		BeforeEach(func() {
 			fakeClient = newFakeClient()
-			component, _ = cfcomponent.NewComponent(loggertesthelper.Logger(), "compType", 3, nil, 9999, []string{"username", "password"}, nil)
+			component, _ = cfcomponent.NewComponent(loggertesthelper.Logger(), "compType", 3, nil, 9999, []string{"username", "password"}, nil, "jobname")
 			component.UUID = "OurUUID"
 			errorProvider = func() error {
 				return nil
@@ -64,7 +64,7 @@ var _ = Describe("Collectorregistrar", func() {
 				}).Should(BeNumerically(">", 1))
 
 				for _, message := range messages {
-					Expect(message.Data).To(MatchRegexp(`^\{"type":"compType","index":3,"host":"[^:]*:9999","uuid":"3-OurUUID","credentials":\["username","password"\]\}$`))
+					Expect(message.Data).To(MatchRegexp(`^\{"type":"compType","index":3,"job_name":"jobname","host":"[^:]*:9999","uuid":"3-OurUUID","credentials":\["username","password"\]\}$`))
 				}
 			})
 

--- a/cfcomponent/registrars/legacycollectorregistrar/collector_messages.go
+++ b/cfcomponent/registrars/legacycollectorregistrar/collector_messages.go
@@ -12,6 +12,7 @@ const DiscoverComponentMessageSubject = "vcap.component.discover"
 type AnnounceComponentMessage struct {
 	Type        string   `json:"type"`
 	Index       uint     `json:"index"`
+	JobName     string   `json:"job_name,omitempty"`
 	Host        string   `json:"host"`
 	UUID        string   `json:"uuid"`
 	Credentials []string `json:"credentials"`
@@ -21,6 +22,7 @@ func NewAnnounceComponentMessage(cfc cfcomponent.Component) (message *AnnounceCo
 	message = &AnnounceComponentMessage{
 		Type:        cfc.Type,
 		Index:       cfc.Index,
+		JobName:     cfc.JobName,
 		Host:        fmt.Sprintf("%s:%d", cfc.IpAddress, cfc.StatusPort),
 		UUID:        fmt.Sprintf("%d-%s", cfc.Index, cfc.UUID),
 		Credentials: cfc.StatusCredentials,

--- a/cfcomponent/registrars/legacycollectorregistrar/collector_registrar_test.go
+++ b/cfcomponent/registrars/legacycollectorregistrar/collector_registrar_test.go
@@ -53,6 +53,7 @@ func createYagnatsMessage(t *testing.T, subject string) ([]byte, *nats.Msg) {
 	expected := &AnnounceComponentMessage{
 		Type:        "Loggregator Server",
 		Index:       0,
+		JobName:     "jobname",
 		Host:        "1.2.3.4:5678",
 		UUID:        "0-abc123",
 		Credentials: []string{"user", "pass"},
@@ -75,6 +76,7 @@ func getTestCFComponent() cfcomponent.Component {
 		IpAddress:         "1.2.3.4",
 		Type:              "Loggregator Server",
 		Index:             0,
+		JobName:           "jobname",
 		StatusPort:        5678,
 		StatusCredentials: []string{"user", "pass"},
 		UUID:              "abc123",


### PR DESCRIPTION
Including the JobName as an optional last argument in the component. Not all users of this "common" package might be adapted at the same time.

Honestly, I doubt that this is the idiomatic golang way to do it, but I've no better idea right now. If you have suggestions, please let me know. Thanks!