### PR TITLE
Check errors in tests - don't eat them

### DIFF
--- a/loggregatorclient/loggregator_client_test.go
+++ b/loggregatorclient/loggregator_client_test.go
@@ -24,8 +24,11 @@ var _ = Describe("loggregatorclient", func() {
 		loggregatorAddress = net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 		loggregatorClient = loggregatorclient.NewLoggregatorClient(loggregatorAddress, gosteno.NewLogger("TestLogger"), 0)
 
-		udpAddr, _ := net.ResolveUDPAddr("udp", loggregatorAddress)
-		udpListener, _ = net.ListenUDP("udp", udpAddr)
+		udpAddr, err := net.ResolveUDPAddr("udp", loggregatorAddress)
+		Expect(err).NotTo(HaveOccurred())
+
+		udpListener, err = net.ListenUDP("udp", udpAddr)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -39,11 +42,11 @@ var _ = Describe("loggregatorclient", func() {
 		loggregatorClient.Send(expectedOutput)
 
 		buffer := make([]byte, 4096)
-		readCount, _, _ := udpListener.ReadFromUDP(buffer)
+		readCount, _, err := udpListener.ReadFromUDP(buffer)
+		Expect(err).NotTo(HaveOccurred())
 
 		received := string(buffer[:readCount])
 		Expect(received).To(Equal(string(expectedOutput)))
-
 	})
 
 	It("doesn't send empty data", func() {
@@ -55,7 +58,8 @@ var _ = Describe("loggregatorclient", func() {
 		loggregatorClient.Send(secondMessage)
 
 		buffer := make([]byte, bufferSize)
-		readCount, _, _ := udpListener.ReadFromUDP(buffer)
+		readCount, _, err := udpListener.ReadFromUDP(buffer)
+		Expect(err).NotTo(HaveOccurred())
 
 		received := string(buffer[:readCount])
 		Expect(received).To(Equal(string(secondMessage)))


### PR DESCRIPTION
A bind failure caused a panic that was much harder to diagnose than it should have been.